### PR TITLE
Winrt compile fix getenv

### DIFF
--- a/libmodplug/stdafx.h
+++ b/libmodplug/stdafx.h
@@ -24,6 +24,11 @@
 
 #if defined(_WIN32) || defined(HX_WINRT)
 
+#if defined(HX_WINRT) && !defined(_CRT_USE_WINAPI_FAMILY_DESKTOP_APP)
+//define getenv on older Windows 10 SDKs
+#define _CRT_USE_WINAPI_FAMILY_DESKTOP_APP
+#endif
+
 #ifdef MSC_VER
 #pragma warning (disable:4201)
 #pragma warning (disable:4514)
@@ -56,10 +61,6 @@ inline int8_t * GlobalAllocPtr(unsigned int, size_t size)
   int8_t * p = (int8_t *) malloc(size);
   if (p != NULL) memset(p, 0, size);
   return p;
-}
-inline static char* getenv(const char *name)
-{
-	return NULL;
 }
 #define GlobalFreePtr(p) free((void *)(p))
 #define wsprintf			sprintf

--- a/libmodplug/stdafx.h
+++ b/libmodplug/stdafx.h
@@ -24,11 +24,6 @@
 
 #if defined(_WIN32) || defined(HX_WINRT)
 
-#if defined(HX_WINRT) && !defined(_CRT_USE_WINAPI_FAMILY_DESKTOP_APP)
-//define getenv on older Windows 10 SDKs
-#define _CRT_USE_WINAPI_FAMILY_DESKTOP_APP
-#endif
-
 #ifdef MSC_VER
 #pragma warning (disable:4201)
 #pragma warning (disable:4514)

--- a/load_abc.cpp
+++ b/load_abc.cpp
@@ -2404,7 +2404,11 @@ static ABCHANDLE *ABC_Init(void)
 		retval->line        = NULL;
 		strcpy(retval->gchord, "");
 		retval->barticks    = 0;
+#ifdef HX_WINRT
+		p = NULL;
+#else
 		p = getenv(ABC_ENV_NORANDOMPICK);
+#endif
 		if( p ) {
 			if( isdigit(*p) )
 				retval->pickrandom = atoi(p);
@@ -5050,7 +5054,12 @@ BOOL CSoundFile::ReadABC(const uint8_t *lpStream, DWORD dwMemLength)
 	ord  = calculated
 
 */
-	if( (p=getenv(ABC_ENV_DUMPTRACKS)) ) {
+#ifdef HX_WINRT
+	p = NULL;
+#else
+	p = getenv(ABC_ENV_DUMPTRACKS);
+#endif
+	if( p ) {
 		printf("P:%s\n",abcparts);
 		for( t=0; t<26; t++ )
 			if( partpat[t][1] >= partpat[t][0] )

--- a/load_mid.cpp
+++ b/load_mid.cpp
@@ -1441,8 +1441,13 @@ BOOL CSoundFile::ReadMID(const BYTE *lpStream, DWORD dwMemLength)
 	mm.sz = dwMemLength;
 	mm.pos = 0;
 #endif
+#ifdef HX_WINRT
+	h->debug = NULL;
+	h->verbose = NULL;
+#else
 	h->debug = getenv(ENV_MMMID_DEBUG);
 	h->verbose = getenv(ENV_MMMID_VERBOSE);
+#endif
 	pat_resetsmp();
 	pat_init_patnames();
 	mmfseek(h->mmf,8,SEEK_SET);
@@ -1460,7 +1465,11 @@ BOOL CSoundFile::ReadMID(const BYTE *lpStream, DWORD dwMemLength)
 	m_nDefaultTempo = 0;
 	h->tracktime = 0;
 	h->speed = 6;
+#ifdef HX_WINRT
+	p = NULL;
+#else
 	p = (BYTE *)getenv(ENV_MMMID_SPEED);
+#endif
 	if( p && isdigit(*p) && p[0] != '0' && p[1] == '\0' ) {
 		// transform speed
 		t = *p - '0';

--- a/load_pat.cpp
+++ b/load_pat.cpp
@@ -404,7 +404,11 @@ void pat_init_patnames(void)
 	MMSTREAM *mmcfg;
 	strcpy(pathforpat, PATHFORPAT);
 	strcpy(timiditycfg, TIMIDITYCFG);
+#ifdef	HX_WINRT
+	p = NULL;
+#else
 	p = getenv(PAT_ENV_PATH2CFG);
+#endif
 	if( p ) {
 		strcpy(timiditycfg,p);
 		strcpy(pathforpat,p);


### PR DESCRIPTION
getenv is already defined as default on newer Windows SDKs (tested 10.0.17134). It can be set on older ones using the _CRT_USE_WINAPI_FAMILY_DESKTOP_APP macro instead of defining the function explicitly.